### PR TITLE
fix: remove catch all error message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,15 +50,11 @@ export class DrizzleAdapter<
 
     async loadPolicy(model: Model): Promise<void> {
         let lines: TCasinTable[]
-        try {
-            // @ts-expect-error
-            lines = await this.#db.query.casbinTable.findMany()
+        // @ts-expect-error
+        lines = await this.#db.query.casbinTable.findMany()
 
-            for (const line of lines) {
-                this.#loadPolicyLine(line, model)
-            }
-        } catch (error) {
-            throw new Error("table must named 'casbinTable'")
+        for (const line of lines) {
+            this.#loadPolicyLine(line, model)
         }
     }
 


### PR DESCRIPTION
This try catch always returns the error 

```
table must named 'casbinTable'
```

even when thats not the original problem. In my case, the env variables were not setup correctly, and the actual error was 

```
error: password authentication failed for user "postgres"
```
but because this try catch catches all errors, it obscures it. I suggest removing the try and exposing the actual error.

