### PR TITLE
feat: implement BatchAdapter and FilteredAdapter, widen driver support

### DIFF
--- a/.changeset/olive-hornets-declare.md
+++ b/.changeset/olive-hornets-declare.md
@@ -1,0 +1,24 @@
+---
+"casbin-drizzle-adapter": patch
+---
+
+Emit type declarations with `tsc` instead of tsup's dts pass.
+
+tsup forces `baseUrl` onto the compiler when it generates declarations
+(`baseUrl: compilerOptions.baseUrl || "."`, in its rollup worker). `baseUrl` is
+deprecated: TypeScript 6 errors on it and TypeScript 7 removes it, so `pnpm build`
+failed outright on TS 6 with `TS5101`. No tsconfig setting prevents the injection,
+because tsup overrides whatever the tsconfig says. The previous workaround —
+`"ignoreDeprecations": "6.0"` in `tsconfig.json` — silences the error for exactly
+one major version and stops being accepted on the next.
+
+-   `tsup` now builds JavaScript only; `tsc -p tsconfig.build.json` emits the
+    declarations, and `scripts/copy-declarations.mjs` writes the `.d.mts` twin each
+    ESM entry needs. A `.d.ts` in a `"type": "commonjs"` package is read as
+    CommonJS, which would type the `.mjs` output as CommonJS for consumers.
+-   Declarations are no longer bundled into one file per entry, so `dist/types.d.ts`
+    now ships alongside them. Both are covered by the existing `"files": ["dist"]`.
+-   The two relative imports in `src` are written with an explicit `.js` extension.
+    Rolled-up declarations had no relative specifiers at all; emitted ones do, and
+    an extensionless specifier is an error for consumers on `node16`/`nodenext`
+    module resolution who do not set `skipLibCheck`.

--- a/.changeset/proud-moons-invite.md
+++ b/.changeset/proud-moons-invite.md
@@ -1,0 +1,35 @@
+---
+"casbin-drizzle-adapter": minor
+---
+
+Implement `BatchAdapter` and `FilteredAdapter`, and widen driver support.
+
+-   `addPolicies` and `removePolicies` are implemented, so `e.addPolicies()`,
+    `e.addPoliciesEx()` and `e.removePolicies()` work. They previously threw
+    `cannot to save policy, the adapter does not implement the BatchAdapter`. Each
+    validates every rule before writing, runs in one transaction, and chunks its
+    statements. An empty batch is a no-op — in particular `removePolicies(sec,
+ptype, [])` cannot render a `DELETE` without a `WHERE` clause.
+-   `loadFilteredPolicy` and `isFiltered` are implemented, so `e.loadFilteredPolicy()`
+    works instead of throwing. The filter is pushed into SQL rather than applied in
+    memory: rules are selected per ptype by position, `""` matches anything, and a
+    ptype the filter does not name is read in full. `savePolicy` now refuses to run
+    after a filtered load, which would otherwise delete every rule outside the filter.
+-   `loadPolicy` carries an `@deprecated` tag pointing at `loadFilteredPolicy`. It
+    remains supported and correct — casbin's `Adapter` interface requires it and
+    `newEnforcer` calls it — but it reads the whole table into memory.
+-   Postgres and MySQL are typed against drizzle's dialect base classes instead of
+    `NodePgDatabase` and `MySql2Database`, so postgres.js, neon, vercel-postgres,
+    PGlite and planetscale are accepted. `better-sqlite3` is still excluded: it runs
+    transaction callbacks synchronously and would not await the adapter's writes.
+-   New subpath exports `casbin-drizzle-adapter/pg`, `/mysql` and `/sqlite` export
+    `pgCasbinTable`, `mysqlCasbinTable` and `sqliteCasbinTable`, which build a
+    correctly shaped table and index `(ptype, v0, v1)`. They are separate entry
+    points so a Postgres user does not load the MySQL and SQLite dialect code.
+-   The package now declares an `exports` map and `"sideEffects": false`. Deep
+    imports into `casbin-drizzle-adapter/dist/*` no longer resolve; use the package
+    entry or one of the subpaths.
+-   MySQL and SQLite are now covered by tests rather than types alone, and a smoke
+    test loads the built package through every entry point in both module formats.
+-   `casbin` and `drizzle-orm` are declared as peer dependencies. They are required
+    at runtime but were listed nowhere, so installing the package pulled in neither.

--- a/.changeset/tidy-typings-guard.md
+++ b/.changeset/tidy-typings-guard.md
@@ -1,0 +1,21 @@
+---
+"casbin-drizzle-adapter": minor
+---
+
+Make the table types catch a wrong casbin table at compile time.
+
+-   `TCasbinSchema` now requires the table to expose `ptype` and `v0..v5`. Passing a
+    table without them was already rejected by the constructor at runtime; it is now
+    a type error, and the message names the missing columns.
+-   The `v0..v5` columns must be nullable text. A NOT NULL policy column cannot store
+    a rule shorter than six values, and `updatePolicy` clears unused columns by
+    writing NULL, so such a table failed on its first short rule. It no longer
+    compiles. `ptype` is written on every row and may stay NOT NULL.
+-   The row types no longer claim an `id` column. The adapter never reads or writes
+    one, so a table without `id` is typed honestly, and `ptype` is now required
+    rather than optional on the value the adapter writes.
+-   The row and column types are derived from a single list of policy columns, so
+    they cannot drift from the columns the adapter actually touches.
+
+Only the property keys are constrained, never the SQL names: the table and each of
+its columns may still be named anything in the database.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
     push:
         branches:
             - main
+    pull_request:
+        branches:
+            - main
 
 jobs:
     test:
@@ -22,6 +25,26 @@ jobs:
                     POSTGRES_USER: casbin
                     POSTGRES_PASSWORD: casbin
                     POSTGRES_DB: casbin
+                options: >-
+                    --health-cmd="pg_isready -U casbin"
+                    --health-interval=5s
+                    --health-timeout=5s
+                    --health-retries=20
+
+            mysql:
+                image: mysql:8
+                ports:
+                    - 3306:3306
+                env:
+                    MYSQL_ROOT_PASSWORD: casbin
+                    MYSQL_DATABASE: casbin
+                # `mysqladmin ping` reports ready ~30s before the server will
+                # accept a query, so health-check with an actual query.
+                options: >-
+                    --health-cmd="mysql -uroot -pcasbin -e 'select 1' casbin"
+                    --health-interval=5s
+                    --health-timeout=5s
+                    --health-retries=30
 
         steps:
             - uses: actions/checkout@v4
@@ -40,13 +63,17 @@ jobs:
             - name: Run test
               run: |
                   export DATABASE_URL=postgres://casbin:casbin@localhost:5432/casbin?sslmode=disable
+                  export MYSQL_URL=mysql://root:casbin@127.0.0.1:3306/casbin
                   pnpm push
-                  pnpm format
+                  pnpm format:check
                   pnpm lint
+                  pnpm typecheck
+                  pnpm build
                   pnpm test run
 
     release:
         needs: test
+        if: github.event_name == 'push'
         runs-on: ubuntu-latest
 
         strategy:

--- a/README.md
+++ b/README.md
@@ -2,32 +2,52 @@
 
 This Adapter is based on [Prisma Adapter](https://github.com/node-casbin/prisma-adapter)
 
-Drizzle Adapter is the [Drizzle](https://github.com/drizzle-team/drizzle-orm) adapter for [Node-Casbin](https://github.com/casbin/node-casbin). With this library, Node-Casbin can load policy from Drizzle supported database or save policy to it.
+Drizzle Adapter is the [Drizzle](https://github.com/drizzle-team/drizzle-orm) adapter for [Node-Casbin](https://github.com/casbin/node-casbin). With this library, Node-Casbin can load policy from a Drizzle-supported database or save policy to it.
 
 Based on [Officially Supported Databases](https://orm.drizzle.team/docs), the current supported databases are:
 
--   PostgreSQL
--   MySQL
--   SQLite
+-   PostgreSQL — any driver (node-postgres, postgres.js, neon, vercel-postgres, PGlite, ...)
+-   MySQL — any driver (mysql2, planetscale, ...)
+-   SQLite — drivers with **asynchronous** transactions (libsql, D1, ...)
+
+`better-sqlite3` is not supported: it runs transaction callbacks synchronously and
+would not await this adapter's writes. The type signature rejects it.
 
 ## Installation
 
 ```
-pnpm add casbin-drizzle-adapter
+pnpm add casbin-drizzle-adapter casbin drizzle-orm
 ```
+
+`casbin` and `drizzle-orm` are peer dependencies, alongside whichever database
+driver you already use (`pg`, `mysql2`, `@libsql/client`, ...).
 
 ## Getting Started
 
-Note on SQLite: only drivers with asynchronous transactions (libsql, D1, ...) are
-supported. `better-sqlite3` runs transaction callbacks synchronously and would not
-await the adapter's writes.
+### 1. Define the table
 
-Create table(PostgreSQL):
+The quickest way is the bundled helper, which also indexes the columns every
+lookup uses:
+
+```ts
+import { pgCasbinTable } from "casbin-drizzle-adapter/pg"
+
+export const casbinTable = pgCasbinTable("casbin_rule")
+```
+
+`casbin-drizzle-adapter/mysql` and `casbin-drizzle-adapter/sqlite` export
+`mysqlCasbinTable` and `sqliteCasbinTable` for the other dialects.
+
+Or define it yourself — the adapter accepts any table with the right shape:
 
 ```ts
 import { pgTable, serial, varchar } from "drizzle-orm/pg-core"
 
-// The table may be named anything; it must define ptype and v0..v5.
+// Only the property keys matter, never the SQL names: the table may be called
+// anything and each column may map to any database column, but the keys ptype
+// and v0..v5 must all be present. v0..v5 must be nullable — a rule shorter than
+// six values is stored with its unused columns left NULL. Any other column (id
+// here) is never written by the adapter, so it must be generated or nullable.
 export const casbinTable = pgTable("casbin_rule", {
     id: serial("id").primaryKey().notNull(),
     ptype: varchar("ptype", { length: 254 }),
@@ -40,7 +60,10 @@ export const casbinTable = pgTable("casbin_rule", {
 })
 ```
 
-Here is a simple example with `PostgreSQL`:
+A table missing those columns, or declaring `v0..v5` as `NOT NULL`, is a
+compile-time error — and still a constructor error for JavaScript callers.
+
+### 2. Create the enforcer
 
 ```ts
 import casbin from "casbin"
@@ -59,7 +82,7 @@ async function main() {
     const e = await casbin.newEnforcer("examples/rbac_model.conf", a)
 
     // Check the permission.
-    e.enforce("alice", "data1", "read")
+    await e.enforce("alice", "data1", "read")
 
     // Modify the policy.
     // await e.addPolicy(...);
@@ -71,6 +94,60 @@ async function main() {
 
 main()
 ```
+
+## Batched writes
+
+`addPolicies` and `removePolicies` are implemented, so the enforcer's batch APIs
+work. Each validates every rule before writing any of them, runs in a single
+transaction, and chunks its statements to stay inside the database's bind
+parameter limit:
+
+```ts
+await e.addPolicies([
+    ["alice", "data1", "read"],
+    ["bob", "data2", "write"],
+])
+```
+
+## Large policy tables
+
+`loadPolicy` reads the entire table into memory. Once that is too much, filter the
+load and casbin only ever sees the rules you asked for. The filter is pushed into
+SQL, not applied afterwards:
+
+```ts
+// p = sub, dom, obj, act  →  the tenant is v1
+// g = _, _, _             →  the tenant is v2
+await e.loadFilteredPolicy({ p: ["", "tenant_a"], g: ["", "", "tenant_a"] })
+```
+
+Each array holds the values a rule must have at `v0`, `v1`, ... in order. `""`
+matches anything at that position, and a ptype the filter does not name is loaded
+in full — the same semantics as casbin's own filtered adapters.
+
+**There is no tenant column.** A rule is only filterable by values it already
+stores, which is what casbin's domain models are for: put the tenant in the rule
+and it lands in a policy column. Note that it sits at a different index per ptype,
+which is why the filter is written per ptype.
+
+Two things to know:
+
+-   A filter narrower than your model needs is **not an error**. The missing rules
+    never load, so `enforce` reports a deny rather than failing loudly.
+-   `savePolicy` is refused after a filtered load. The model holds only the rules
+    that filter matched, so writing it back would delete every rule outside the
+    filter. Call `loadPolicy` first if you really mean to replace everything.
+
+Use `adapter.isFiltered()` to check which state you are in.
+
+## Supported casbin interfaces
+
+| Interface          | Methods                                                       |
+| ------------------ | ------------------------------------------------------------- |
+| `Adapter`          | `loadPolicy`, `savePolicy`, `addPolicy`, `removePolicy`, `removeFilteredPolicy` |
+| `BatchAdapter`     | `addPolicies`, `removePolicies`                                |
+| `FilteredAdapter`  | `loadFilteredPolicy`, `isFiltered`                             |
+| `UpdatableAdapter` | `updatePolicy`                                                 |
 
 ## Getting Help
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,15 @@ export default [
     },
     js.configs.recommended,
     {
+        // Build scripts: plain ESM running on Node.
+        files: ["**/*.mjs"],
+        languageOptions: {
+            globals: {
+                ...globals.node,
+            },
+        },
+    },
+    {
         files: ["**/*.ts"],
         languageOptions: {
             parser: tsParser,

--- a/package.json
+++ b/package.json
@@ -5,10 +5,56 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "module": "dist/index.mjs",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./dist/index.d.mts",
+                "default": "./dist/index.mjs"
+            },
+            "require": {
+                "types": "./dist/index.d.ts",
+                "default": "./dist/index.js"
+            }
+        },
+        "./pg": {
+            "import": {
+                "types": "./dist/table/pg.d.mts",
+                "default": "./dist/table/pg.mjs"
+            },
+            "require": {
+                "types": "./dist/table/pg.d.ts",
+                "default": "./dist/table/pg.js"
+            }
+        },
+        "./mysql": {
+            "import": {
+                "types": "./dist/table/mysql.d.mts",
+                "default": "./dist/table/mysql.mjs"
+            },
+            "require": {
+                "types": "./dist/table/mysql.d.ts",
+                "default": "./dist/table/mysql.js"
+            }
+        },
+        "./sqlite": {
+            "import": {
+                "types": "./dist/table/sqlite.d.mts",
+                "default": "./dist/table/sqlite.mjs"
+            },
+            "require": {
+                "types": "./dist/table/sqlite.d.ts",
+                "default": "./dist/table/sqlite.js"
+            }
+        },
+        "./package.json": "./package.json"
+    },
+    "sideEffects": false,
     "scripts": {
-        "build": "tsup --minify",
-        "format": "prettier -w \"src/**/*.ts\"",
-        "lint": "eslint src --max-warnings 0",
+        "build": "tsup --minify && tsc -p tsconfig.build.json && node scripts/copy-declarations.mjs",
+        "format": "prettier -w \"**/*.{ts,mjs,json,yml}\"",
+        "format:check": "prettier -c \"**/*.{ts,mjs,json,yml}\"",
+        "typecheck": "tsc --noEmit",
+        "lint": "eslint . --max-warnings 0",
         "test": "dotenv -- vitest",
         "push": "dotenv -- drizzle-kit push",
         "release": "changeset version"
@@ -29,9 +75,14 @@
     ],
     "author": "hngngn <hngngn.dev@gmail.com>",
     "license": "MIT",
+    "peerDependencies": {
+        "casbin": "^5.0.0",
+        "drizzle-orm": ">=0.36.0"
+    },
     "devDependencies": {
         "@changesets/cli": "^3.0.1",
         "@eslint/js": "^10.0.1",
+        "@libsql/client": "^0.17.4",
         "@types/node": "^26.2.0",
         "@types/pg": "^8.23.1",
         "@typescript-eslint/eslint-plugin": "^8.67.0",
@@ -42,6 +93,7 @@
         "drizzle-orm": "^0.45.2",
         "eslint": "^10.8.1",
         "globals": "^17.11.0",
+        "mysql2": "^3.23.4",
         "pg": "^8.23.0",
         "prettier": "^3.9.6",
         "tsup": "^8.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.8.1)
+      '@libsql/client':
+        specifier: ^0.17.4
+        version: 0.17.4
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0
@@ -37,13 +40,16 @@ importers:
         version: 0.31.10
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@types/pg@8.23.1)(pg@8.23.0)
+        version: 0.45.2(@libsql/client@0.17.4)(@types/pg@8.23.1)(mysql2@3.23.4(@types/node@26.2.0))(pg@8.23.0)
       eslint:
         specifier: ^10.8.1
         version: 10.8.1
       globals:
         specifier: ^17.11.0
         version: 17.11.0
+      mysql2:
+        specifier: ^3.23.4
+        version: 3.23.4(@types/node@26.2.0)
       pg:
         specifier: ^8.23.0
         version: 8.23.0
@@ -820,6 +826,63 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@libsql/client@0.17.4':
+    resolution: {integrity: sha512-lYayFWasDV78A+TjlEhr6ubb3odBV6OHjb+wdp8VQcyWWAEIjuwbCHaraEUS4m4yWoo0BvZo96It4VdzZRmRWw==}
+
+  '@libsql/core@0.17.4':
+    resolution: {integrity: sha512-LqF9gIvnJ38nmAH1y/ChizHqDO/MO1wLgA96XrraulEEbqXxLjleSH92YWTolbuJKgPUmGu4aJk9W3UnAcxLOQ==}
+
+  '@libsql/darwin-arm64@0.5.29':
+    resolution: {integrity: sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@libsql/darwin-x64@0.5.29':
+    resolution: {integrity: sha512-OtT+KFHsKFy1R5FVadr8FJ2Bb1mghtXTyJkxv0trocq7NuHntSki1eUbxpO5ezJesDvBlqFjnWaYYY516QNLhQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@libsql/hrana-client@0.10.0':
+    resolution: {integrity: sha512-OoA4EMqRAC7kn7V2P6EQqRcpZf2W+AjsNIyCizBg339Tq/aMC7sRnzs3SklderhmQWAqEzvv8A2vhxVmWpkVvw==}
+
+  '@libsql/isomorphic-ws@0.1.5':
+    resolution: {integrity: sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==}
+
+  '@libsql/linux-arm-gnueabihf@0.5.29':
+    resolution: {integrity: sha512-CD4n4zj7SJTHso4nf5cuMoWoMSS7asn5hHygsDuhRl8jjjCTT3yE+xdUvI4J7zsyb53VO5ISh4cwwOtf6k2UhQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@libsql/linux-arm-musleabihf@0.5.29':
+    resolution: {integrity: sha512-2Z9qBVpEJV7OeflzIR3+l5yAd4uTOLxklScYTwpZnkm2vDSGlC1PRlueLaufc4EFITkLKXK2MWBpexuNJfMVcg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@libsql/linux-arm64-gnu@0.5.29':
+    resolution: {integrity: sha512-gURBqaiXIGGwFNEaUj8Ldk7Hps4STtG+31aEidCk5evMMdtsdfL3HPCpvys+ZF/tkOs2MWlRWoSq7SOuCE9k3w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@libsql/linux-arm64-musl@0.5.29':
+    resolution: {integrity: sha512-fwgYZ0H8mUkyVqXZHF3mT/92iIh1N94Owi/f66cPVNsk9BdGKq5gVpoKO+7UxaNzuEH1roJp2QEwsCZMvBLpqg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@libsql/linux-x64-gnu@0.5.29':
+    resolution: {integrity: sha512-y14V0vY0nmMC6G0pHeJcEarcnGU2H6cm21ZceRkacWHvQAEhAG0latQkCtoS2njFOXiYIg+JYPfAoWKbi82rkg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@libsql/linux-x64-musl@0.5.29':
+    resolution: {integrity: sha512-gquqwA/39tH4pFl+J9n3SOMSymjX+6kZ3kWgY3b94nXFTwac9bnFNMffIomgvlFaC4ArVqMnOZD3nuJ3H3VO1w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@libsql/win32-x64-msvc@0.5.29':
+    resolution: {integrity: sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg==}
+    cpu: [x64]
+    os: [win32]
+
   '@manypkg/find-root@3.1.0':
     resolution: {integrity: sha512-BcSqCyKhBVZ5YkSzOiheMCV41kqAFptW6xGqYSTjkVTl9XQpr+pqHhwgGCOHQtjDCv7Is6EFyA14Sm5GVbVABA==}
     engines: {node: '>=20.0.0'}
@@ -838,6 +901,9 @@ packages:
     cpu: [x64]
     os: [linux]
     libc: [glibc]
+
+  '@neon-rs/load@0.0.4':
+    resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
   '@oxc-project/types@0.146.0':
     resolution: {integrity: sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==}
@@ -1107,6 +1173,9 @@ packages:
   '@types/pg@8.23.1':
     resolution: {integrity: sha512-fKVHpikPdg4GKks3JuLEhvwSyvwzF23hnabPy6DD8ljVbC7+6J5dQzdv4arV6jqq57djnMgs1HKBxX4P8aBI3A==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript-eslint/eslint-plugin@8.67.0':
     resolution: {integrity: sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1218,6 +1287,10 @@ packages:
   await-lock@2.2.2:
     resolution: {integrity: sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==}
 
+  aws-ssl-profiles@1.1.2:
+    resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
+    engines: {node: '>= 6.0.0'}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1292,6 +1365,10 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  detect-libc@2.0.2:
+    resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
+    engines: {node: '>=8'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1535,6 +1612,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  generate-function@2.3.1:
+    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
+
   get-tsconfig@4.14.3:
     resolution: {integrity: sha512-++QEw4DIY7WGoukz+/+A/8dGYPT9l9yIadnmSgZ8Rjr3YVSVDipQSO9CdnJo9ePqFqUUqh+wk9uIaoiAwsiPkA==}
 
@@ -1549,6 +1629,10 @@ packages:
   human-id@4.2.1:
     resolution: {integrity: sha512-zPGsiS+dWoTZtZ4AtpA9Y+BdSFSNWvnouNlWNoUFyAM6xHOHmdCvqO3k8AIbdamCOv4gUFUVNPf6rJFfc4UiJw==}
     hasBin: true
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1576,6 +1660,9 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-property@1.0.2:
+    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -1585,6 +1672,9 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-base64@3.9.3:
+    resolution: {integrity: sha512-uwYQp+VJ38FVvtim6qNbit6e9uT6dwWQ4Y1+H9TxhW5hcHjpHwoxlR0nMpqUmIFOmu4VqMxwdJA88gIVuZJQ/g==}
 
   jsep@0.3.5:
     resolution: {integrity: sha512-AoRLBDc6JNnKjNcmonituEABS5bcfqDhQAWWXNTFrqu6nVXBpBAGfcoTGZMFlIrh9FjmE1CQyX9CTNwZrXMMDA==}
@@ -1611,6 +1701,11 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libsql@0.5.29:
+    resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
+    cpu: [x64, arm64, wasm32, arm]
+    os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
@@ -1701,6 +1796,13 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  lru.min@1.1.4:
+    resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
+    engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1717,8 +1819,18 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mysql2@3.23.4:
+    resolution: {integrity: sha512-J1Rgl8Oy5iw3mOBjKeTMQ3cJNjMYtJYavQVXShsMtSj9rKV8Q1+QaGKNJqDVQFcNINqYYp6Vxd90r69cCoBxBA==}
+    engines: {node: '>= 8.0'}
+    peerDependencies:
+      '@types/node': '>= 8'
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  named-placeholders@1.1.6:
+    resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
+    engines: {node: '>=8.0.0'}
 
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
@@ -1857,6 +1969,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  promise-limit@2.7.0:
+    resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1881,6 +1996,9 @@ packages:
     resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
@@ -1923,6 +2041,10 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  sql-escaper@1.5.1:
+    resolution: {integrity: sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==}
+    engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -2112,6 +2234,18 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -2624,6 +2758,64 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@libsql/client@0.17.4':
+    dependencies:
+      '@libsql/core': 0.17.4
+      '@libsql/hrana-client': 0.10.0
+      js-base64: 3.9.3
+      libsql: 0.5.29
+      promise-limit: 2.7.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libsql/core@0.17.4':
+    dependencies:
+      js-base64: 3.9.3
+
+  '@libsql/darwin-arm64@0.5.29':
+    optional: true
+
+  '@libsql/darwin-x64@0.5.29':
+    optional: true
+
+  '@libsql/hrana-client@0.10.0':
+    dependencies:
+      '@libsql/isomorphic-ws': 0.1.5
+      js-base64: 3.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libsql/isomorphic-ws@0.1.5':
+    dependencies:
+      '@types/ws': 8.18.1
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libsql/linux-arm-gnueabihf@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm-musleabihf@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm64-gnu@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm64-musl@0.5.29':
+    optional: true
+
+  '@libsql/linux-x64-gnu@0.5.29':
+    optional: true
+
+  '@libsql/linux-x64-musl@0.5.29':
+    optional: true
+
+  '@libsql/win32-x64-msvc@0.5.29':
+    optional: true
+
   '@manypkg/find-root@3.1.0':
     dependencies:
       '@manypkg/tools': 2.1.2
@@ -2641,6 +2833,8 @@ snapshots:
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
+
+  '@neon-rs/load@0.0.4': {}
 
   '@oxc-project/types@0.146.0': {}
 
@@ -2793,6 +2987,10 @@ snapshots:
       pg-protocol: 1.16.0
       pg-types: 2.2.0
 
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 26.2.0
+
   '@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@6.0.3))(eslint@10.8.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -2944,6 +3142,8 @@ snapshots:
 
   await-lock@2.2.2: {}
 
+  aws-ssl-profiles@1.1.2: {}
+
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -3004,6 +3204,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  detect-libc@2.0.2: {}
+
   detect-libc@2.1.2: {}
 
   dotenv-cli@11.0.0:
@@ -3028,9 +3230,11 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.23.12
 
-  drizzle-orm@0.45.2(@types/pg@8.23.1)(pg@8.23.0):
+  drizzle-orm@0.45.2(@libsql/client@0.17.4)(@types/pg@8.23.1)(mysql2@3.23.4(@types/node@26.2.0))(pg@8.23.0):
     optionalDependencies:
+      '@libsql/client': 0.17.4
       '@types/pg': 8.23.1
+      mysql2: 3.23.4(@types/node@26.2.0)
       pg: 8.23.0
 
   es-module-lexer@2.3.2: {}
@@ -3264,6 +3468,10 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  generate-function@2.3.1:
+    dependencies:
+      is-property: 1.0.2
+
   get-tsconfig@4.14.3:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -3275,6 +3483,10 @@ snapshots:
   globals@17.11.0: {}
 
   human-id@4.2.1: {}
+
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -3292,11 +3504,15 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-property@1.0.2: {}
+
   isexe@2.0.0: {}
 
   jju@1.4.0: {}
 
   joycon@3.1.1: {}
+
+  js-base64@3.9.3: {}
 
   jsep@0.3.5: {}
 
@@ -3321,6 +3537,21 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libsql@0.5.29:
+    dependencies:
+      '@neon-rs/load': 0.0.4
+      detect-libc: 2.0.2
+    optionalDependencies:
+      '@libsql/darwin-arm64': 0.5.29
+      '@libsql/darwin-x64': 0.5.29
+      '@libsql/linux-arm-gnueabihf': 0.5.29
+      '@libsql/linux-arm-musleabihf': 0.5.29
+      '@libsql/linux-arm64-gnu': 0.5.29
+      '@libsql/linux-arm64-musl': 0.5.29
+      '@libsql/linux-x64-gnu': 0.5.29
+      '@libsql/linux-x64-musl': 0.5.29
+      '@libsql/win32-x64-msvc': 0.5.29
 
   lightningcss-android-arm64@1.33.0:
     optional: true
@@ -3381,6 +3612,10 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  long@5.3.2: {}
+
+  lru.min@1.1.4: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3400,11 +3635,26 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mysql2@3.23.4(@types/node@26.2.0):
+    dependencies:
+      '@types/node': 26.2.0
+      aws-ssl-profiles: 1.1.2
+      generate-function: 2.3.1
+      iconv-lite: 0.7.3
+      long: 5.3.2
+      lru.min: 1.1.4
+      named-placeholders: 1.1.6
+      sql-escaper: 1.5.1
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
+
+  named-placeholders@1.1.6:
+    dependencies:
+      lru.min: 1.1.4
 
   nanoid@3.3.18: {}
 
@@ -3514,6 +3764,8 @@ snapshots:
 
   prettier@3.9.6: {}
 
+  promise-limit@2.7.0: {}
+
   punycode@2.3.1: {}
 
   readdirp@4.1.2: {}
@@ -3575,6 +3827,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.4
       fsevents: 2.3.3
 
+  safer-buffer@2.1.2: {}
+
   semver@7.8.5: {}
 
   shebang-command@2.0.0:
@@ -3601,6 +3855,8 @@ snapshots:
   source-map@0.7.6: {}
 
   split2@4.2.0: {}
+
+  sql-escaper@1.5.1: {}
 
   stackback@0.0.2: {}
 
@@ -3744,6 +4000,8 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  ws@8.21.3: {}
 
   xtend@4.0.2: {}
 

--- a/scripts/copy-declarations.mjs
+++ b/scripts/copy-declarations.mjs
@@ -1,0 +1,30 @@
+// `tsc` emits one set of declarations, but the package ships two module formats
+// and the exports map points each at its own types file. A `.d.ts` in a
+// `"type": "commonjs"` package is read as CommonJS, so the ESM entry needs a
+// `.d.mts` beside it or consumers see the ESM output typed as CommonJS.
+//
+// The two files are identical. Nothing in this package's public types differs
+// between formats, and every relative specifier is written with a `.js`
+// extension, which resolves under both.
+import { copyFile, readdir } from "node:fs/promises"
+import { join } from "node:path"
+
+const dist = new URL("../dist/", import.meta.url).pathname
+
+const declarations = async (directory) => {
+    const found = []
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+        const path = join(directory, entry.name)
+        if (entry.isDirectory()) {
+            found.push(...(await declarations(path)))
+        } else if (entry.name.endsWith(".d.ts")) {
+            found.push(path)
+        }
+    }
+    return found
+}
+
+const files = await declarations(dist)
+await Promise.all(files.map((file) => copyFile(file, `${file.slice(0, -5)}.d.mts`)))
+
+console.log(`copy-declarations: wrote ${files.length} .d.mts file(s)`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,37 +1,74 @@
-import type { Model, UpdatableAdapter } from "casbin"
-import type { Column, SQL } from "drizzle-orm"
-import { and, eq, getTableColumns, getTableName, isNull } from "drizzle-orm"
-import type { MySqlTable, TableConfig as MySqlTableConfig } from "drizzle-orm/mysql-core"
-import type { MySql2Database } from "drizzle-orm/mysql2"
-import type { NodePgDatabase } from "drizzle-orm/node-postgres"
-import type { PgTable, TableConfig as PgTableConfig } from "drizzle-orm/pg-core"
+import type { BatchAdapter, FilteredAdapter, Model, UpdatableAdapter } from "casbin"
+import {
+    and,
+    eq,
+    getTableColumns,
+    getTableName,
+    isNull,
+    notInArray,
+    or,
+    type Column,
+    type SQL,
+} from "drizzle-orm"
+import type {
+    MySqlDatabase,
+    MySqlQueryResultHKT,
+    MySqlTable,
+    PreparedQueryHKTBase,
+    TableConfig as MySqlTableConfig,
+} from "drizzle-orm/mysql-core"
+import type {
+    PgDatabase,
+    PgQueryResultHKT,
+    PgTable,
+    TableConfig as PgTableConfig,
+} from "drizzle-orm/pg-core"
 import type {
     BaseSQLiteDatabase,
     SQLiteTable,
     TableConfig as SQLiteTableConfig,
 } from "drizzle-orm/sqlite-core"
-import type { TCasinTable, TCasinTableCreateInput } from "./types"
+import type {
+    TCasbinColumns,
+    TCasbinFilter,
+    TCasbinTable,
+    TCasbinTableCreateInput,
+} from "./types.js"
+
+export type { TCasbinFilter } from "./types.js"
 
 /** The policy value columns, in order. A rule may not be longer than this. */
-const POLICY_COLUMNS = ["v0", "v1", "v2", "v3", "v4", "v5"] as const
+export const POLICY_COLUMNS = ["v0", "v1", "v2", "v3", "v4", "v5"] as const
 
 /** Every column the adapter reads or writes. */
 const REQUIRED_COLUMNS = ["ptype", ...POLICY_COLUMNS] as const
 
 /** Postgres caps a statement at 65535 bind parameters; stay well inside it. */
-const INSERT_CHUNK_SIZE = 1000
-
-export type TCasbinSchema =
-    PgTable<PgTableConfig> | MySqlTable<MySqlTableConfig> | SQLiteTable<SQLiteTableConfig>
+const STATEMENT_CHUNK_SIZE = 1000
 
 /**
+ * Any drizzle table that carries the casbin columns. The intersection is what
+ * makes a wrong table a compile error rather than a constructor throw; the
+ * constructor still checks, because a JavaScript caller reaches it untyped.
+ */
+export type TCasbinSchema =
+    | (PgTable<PgTableConfig> & TCasbinColumns)
+    | (MySqlTable<MySqlTableConfig> & TCasbinColumns)
+    | (SQLiteTable<SQLiteTableConfig> & TCasbinColumns)
+
+/**
+ * Typed against drizzle's dialect base classes rather than a single driver, so
+ * every Postgres and MySQL driver is accepted: node-postgres, postgres.js, neon,
+ * vercel-postgres, PGlite, planetscale, ...
+ *
  * SQLite is only supported through drivers with asynchronous transactions
- * (libsql, D1, ...). `better-sqlite3` runs transaction callbacks synchronously
- * and would not await this adapter's writes.
+ * (libsql, D1, ...). `better-sqlite3` is `BaseSQLiteDatabase<"sync", ...>`: it
+ * runs transaction callbacks synchronously and would not await this adapter's
+ * writes, so the union excludes it on purpose.
  */
 export type TCasbinDatabase<TSchema extends Record<string, unknown>> =
-    | NodePgDatabase<TSchema>
-    | MySql2Database<TSchema>
+    | PgDatabase<PgQueryResultHKT, TSchema>
+    | MySqlDatabase<MySqlQueryResultHKT, PreparedQueryHKTBase, TSchema>
     | BaseSQLiteDatabase<"async", unknown, TSchema>
 
 /**
@@ -43,10 +80,18 @@ export type TCasbinDatabase<TSchema extends Record<string, unknown>> =
  * that the table really has the columns this shape assumes.
  */
 type TQueryRunner = {
-    select(): { from(table: TCasbinSchema): PromiseLike<TCasinTable[]> }
-    insert(table: TCasbinSchema): { values(values: TCasinTableCreateInput[]): PromiseLike<unknown> }
+    select(): {
+        from(table: TCasbinSchema): PromiseLike<TCasbinTable[]> & {
+            where(where: SQL | undefined): PromiseLike<TCasbinTable[]>
+        }
+    }
+    insert(table: TCasbinSchema): {
+        values(values: TCasbinTableCreateInput[]): PromiseLike<unknown>
+    }
     update(table: TCasbinSchema): {
-        set(values: TCasinTableCreateInput): { where(where: SQL | undefined): PromiseLike<unknown> }
+        set(values: TCasbinTableCreateInput): {
+            where(where: SQL | undefined): PromiseLike<unknown>
+        }
     }
     delete(table: TCasbinSchema): PromiseLike<unknown> & {
         where(where: SQL | undefined): PromiseLike<unknown>
@@ -57,10 +102,14 @@ type TQueryRunner = {
 export class DrizzleAdapter<
     T extends TCasbinDatabase<TSchema>,
     TSchema extends Record<string, unknown>,
-> implements UpdatableAdapter {
+>
+    implements UpdatableAdapter, BatchAdapter, FilteredAdapter
+{
     #db: TQueryRunner
     #schema: TCasbinSchema
     #columns: Record<string, Column>
+    /** Set by a filtered load, so `savePolicy` cannot write back a partial policy. */
+    #filtered = false
 
     constructor(db: T, schema: TCasbinSchema) {
         if (!db) {
@@ -345,7 +394,7 @@ export class DrizzleAdapter<
         return undefined
     }
 
-    #loadPolicyLine = (line: TCasinTable, model: Model): void => {
+    #loadPolicyLine = (line: TCasbinTable, model: Model): void => {
         const ptype = line.ptype
         if (!ptype) {
             throw new Error(`Invalid policy line: ptype is required but got ${ptype}`)
@@ -371,18 +420,7 @@ export class DrizzleAdapter<
         ast.policy.push(values.slice(0, length).map((value) => value ?? ""))
     }
 
-    async loadPolicy(model: Model): Promise<void> {
-        if (!model) {
-            throw new Error("Model is required for loading policy")
-        }
-
-        let lines: TCasinTable[]
-        try {
-            lines = await this.#db.select().from(this.#schema)
-        } catch (error) {
-            throw this.#categorizeError(error, "loading policy from database")
-        }
-
+    #applyLines = (lines: TCasbinTable[], model: Model): void => {
         try {
             for (const line of lines) {
                 this.#loadPolicyLine(line, model)
@@ -393,7 +431,117 @@ export class DrizzleAdapter<
         }
     }
 
-    #savePolicyLine = (ptype: string, rule: string[]): TCasinTableCreateInput => {
+    /**
+     * Reads every rule in the table.
+     *
+     * @deprecated Prefer {@link DrizzleAdapter.loadFilteredPolicy}, which pushes
+     * the filter down into SQL. This method issues an unbounded `SELECT` and
+     * holds the whole policy in memory, so a table shared by many tenants loads
+     * every tenant to enforce one. casbin's `Adapter` interface requires this
+     * method and `newEnforcer` calls it, so it stays supported and correct — the
+     * tag is guidance for large tables, not a removal notice.
+     */
+    async loadPolicy(model: Model): Promise<void> {
+        if (!model) {
+            throw new Error("Model is required for loading policy")
+        }
+
+        let lines: TCasbinTable[]
+        try {
+            lines = await this.#db.select().from(this.#schema)
+        } catch (error) {
+            throw this.#categorizeError(error, "loading policy from database")
+        }
+
+        this.#applyLines(lines, model)
+        this.#filtered = false
+    }
+
+    /**
+     * Reads only the rules the filter selects, as a single `SELECT ... WHERE`.
+     *
+     * A ptype the filter does not name is read in full, matching casbin's own
+     * filtered adapters. Note that a filter narrower than the model needs is not
+     * an error: the missing rules simply never load, and `enforce` reports a
+     * deny. See {@link TCasbinFilter} for the shape and a multi-tenant example.
+     */
+    async loadFilteredPolicy(model: Model, filter?: TCasbinFilter): Promise<void> {
+        if (!model) {
+            throw new Error("Model is required for loading policy")
+        }
+
+        const where = this.#filterCondition(filter)
+        if (!where) {
+            // Constrains nothing, so this is a full load — and a full load must
+            // not leave the adapter marked filtered, or savePolicy stays locked.
+            await this.loadPolicy(model)
+            return
+        }
+
+        let lines: TCasbinTable[]
+        try {
+            lines = await this.#db.select().from(this.#schema).where(where)
+        } catch (error) {
+            throw this.#categorizeError(error, "loading filtered policy from database")
+        }
+
+        this.#applyLines(lines, model)
+        this.#filtered = true
+    }
+
+    /** True when the loaded policy is a subset of the table. */
+    isFiltered(): boolean {
+        return this.#filtered
+    }
+
+    /**
+     * Renders a filter as, for example,
+     * `(ptype = 'p' AND v1 = 'tenant_a') OR (ptype = 'g' AND v2 = 'tenant_a')
+     * OR ptype NOT IN ('p', 'g')` — the last branch being the ptypes the filter
+     * says nothing about. Returns undefined when the filter constrains nothing.
+     */
+    #filterCondition = (filter: TCasbinFilter | undefined): SQL | undefined => {
+        if (!filter) {
+            return undefined
+        }
+
+        const named = Object.keys(filter).filter((ptype) => filter[ptype] !== undefined)
+        if (named.length === 0) {
+            return undefined
+        }
+
+        const branches: SQL[] = []
+        for (const ptype of named) {
+            const values = filter[ptype] ?? []
+            if (values.length > POLICY_COLUMNS.length) {
+                throw new Error(
+                    `Filter for ptype "${ptype}" has ${values.length} values but the casbin ` +
+                        `table stores at most ${POLICY_COLUMNS.length} ` +
+                        `(${POLICY_COLUMNS.join(", ")}): ${JSON.stringify(values)}`,
+                )
+            }
+
+            const conditions: SQL[] = [eq(this.#column("ptype"), ptype)]
+            values.forEach((value, index) => {
+                // casbin's wildcard: an empty string constrains nothing here.
+                if (value === "") {
+                    return
+                }
+                conditions.push(eq(this.#column(POLICY_COLUMNS[index]!), value))
+            })
+
+            const branch = and(...conditions)
+            if (branch) {
+                branches.push(branch)
+            }
+        }
+
+        branches.push(notInArray(this.#column("ptype"), named))
+
+        return or(...branches)
+    }
+
+    #savePolicyLine = (ptype: string, rule: string[]): TCasbinTableCreateInput => {
         if (rule.length > POLICY_COLUMNS.length) {
             throw new Error(
                 `Rule has ${rule.length} values but the casbin table stores at most ` +
@@ -402,7 +550,7 @@ export class DrizzleAdapter<
             )
         }
 
-        const line: TCasinTableCreateInput = { ptype }
+        const line: TCasbinTableCreateInput = { ptype }
         POLICY_COLUMNS.forEach((name, index) => {
             if (index < rule.length) {
                 line[name] = rule[index]
@@ -418,7 +566,7 @@ export class DrizzleAdapter<
      * that merely shares its prefix. `eq(column, null)` renders `column = NULL`,
      * which is never true in SQL, so absent columns need `IS NULL`.
      */
-    #matchLine = (line: TCasinTableCreateInput): SQL | undefined => {
+    #matchLine = (line: TCasbinTableCreateInput): SQL | undefined => {
         const conditions: SQL[] = [eq(this.#column("ptype"), line.ptype)]
 
         for (const name of POLICY_COLUMNS) {
@@ -437,10 +585,21 @@ export class DrizzleAdapter<
         if (!model) {
             throw new Error("Model is required for saving policy")
         }
+        if (this.#filtered) {
+            // savePolicy truncates the table. After a filtered load the model
+            // holds only the rules that filter matched, so writing it back would
+            // delete every rule outside the filter. casbin's enforcer refuses
+            // this too; the adapter refuses it as well for direct callers.
+            throw new Error(
+                "Cannot save a filtered policy: the model holds only the rules the last " +
+                    "filtered load read, and saving would delete every rule outside that " +
+                    "filter. Call loadPolicy() first.",
+            )
+        }
 
         // Build every row before touching the database. A malformed rule must
         // not leave the table truncated with the policy half-written.
-        const lines: TCasinTableCreateInput[] = []
+        const lines: TCasbinTableCreateInput[] = []
         for (const sec of ["p", "g"] as const) {
             // A model without a [role_definition] section has no "g" at all.
             const astMap = model.model.get(sec)
@@ -457,8 +616,8 @@ export class DrizzleAdapter<
         try {
             await this.#db.transaction(async (tx) => {
                 await tx.delete(this.#schema)
-                for (let i = 0; i < lines.length; i += INSERT_CHUNK_SIZE) {
-                    await tx.insert(this.#schema).values(lines.slice(i, i + INSERT_CHUNK_SIZE))
+                for (let i = 0; i < lines.length; i += STATEMENT_CHUNK_SIZE) {
+                    await tx.insert(this.#schema).values(lines.slice(i, i + STATEMENT_CHUNK_SIZE))
                 }
             })
         } catch (error) {
@@ -484,6 +643,43 @@ export class DrizzleAdapter<
         }
     }
 
+    /**
+     * Validates every rule before any of them is written, so a malformed rule in
+     * the middle of a batch cannot leave the table half-updated.
+     */
+    #savePolicyLines = (ptype: string, rules: string[][]): TCasbinTableCreateInput[] => {
+        if (!ptype) {
+            throw new Error("Policy type (ptype) is required")
+        }
+        if (!Array.isArray(rules)) {
+            throw new Error("Rules must be an array")
+        }
+
+        return rules.map((rule) => {
+            if (!Array.isArray(rule)) {
+                throw new Error("Rule must be an array")
+            }
+            return this.#savePolicyLine(ptype, rule)
+        })
+    }
+
+    async addPolicies(sec: string, ptype: string, rules: string[][]): Promise<void> {
+        const lines = this.#savePolicyLines(ptype, rules)
+        if (lines.length === 0) {
+            return
+        }
+
+        try {
+            await this.#db.transaction(async (tx) => {
+                for (let i = 0; i < lines.length; i += STATEMENT_CHUNK_SIZE) {
+                    await tx.insert(this.#schema).values(lines.slice(i, i + STATEMENT_CHUNK_SIZE))
+                }
+            })
+        } catch (error) {
+            throw this.#categorizeError(error, "adding policies")
+        }
+    }
+
     async removePolicy(sec: string, ptype: string, rule: string[]): Promise<void> {
         if (!ptype) {
             throw new Error("Policy type (ptype) is required")
@@ -497,6 +693,29 @@ export class DrizzleAdapter<
             await this.#db.delete(this.#schema).where(this.#matchLine(line))
         } catch (error) {
             throw this.#categorizeError(error, "removing policy")
+        }
+    }
+
+    async removePolicies(sec: string, ptype: string, rules: string[][]): Promise<void> {
+        const lines = this.#savePolicyLines(ptype, rules)
+        // An `or()` over nothing renders no WHERE clause at all, and the delete
+        // would take the whole table with it. Never issue the statement empty.
+        const conditions = lines
+            .map((line) => this.#matchLine(line))
+            .filter((condition): condition is SQL => condition !== undefined)
+        if (conditions.length === 0) {
+            return
+        }
+
+        try {
+            await this.#db.transaction(async (tx) => {
+                for (let i = 0; i < conditions.length; i += STATEMENT_CHUNK_SIZE) {
+                    const chunk = conditions.slice(i, i + STATEMENT_CHUNK_SIZE)
+                    await tx.delete(this.#schema).where(or(...chunk))
+                }
+            })
+        } catch (error) {
+            throw this.#categorizeError(error, "removing policies")
         }
     }
 

--- a/src/table/mysql.ts
+++ b/src/table/mysql.ts
@@ -1,0 +1,21 @@
+import { index, int, mysqlTable, varchar } from "drizzle-orm/mysql-core"
+
+/**
+ * A MySQL casbin table shaped the way the adapter needs it. See
+ * {@link ../pg!pgCasbinTable} for the rationale; the shape is identical.
+ */
+export const mysqlCasbinTable = (name = "casbin_rule", valueLength = 254) =>
+    mysqlTable(
+        name,
+        {
+            id: int("id").autoincrement().primaryKey(),
+            ptype: varchar("ptype", { length: valueLength }),
+            v0: varchar("v0", { length: valueLength }),
+            v1: varchar("v1", { length: valueLength }),
+            v2: varchar("v2", { length: valueLength }),
+            v3: varchar("v3", { length: valueLength }),
+            v4: varchar("v4", { length: valueLength }),
+            v5: varchar("v5", { length: valueLength }),
+        },
+        (table) => [index(`${name}_ptype_v0_v1_idx`).on(table.ptype, table.v0, table.v1)],
+    )

--- a/src/table/pg.ts
+++ b/src/table/pg.ts
@@ -1,0 +1,25 @@
+import { index, pgTable, serial, varchar } from "drizzle-orm/pg-core"
+
+/**
+ * A Postgres casbin table shaped the way the adapter needs it: `ptype` and
+ * `v0..v5` as nullable text, plus an index over the leading columns every
+ * equality lookup uses (`removePolicy`, `updatePolicy`, a filtered load).
+ *
+ * Column names are free — only the property keys matter — so this is a
+ * convenience, not a requirement. Hand-written tables keep working.
+ */
+export const pgCasbinTable = (name = "casbin_rule", valueLength = 254) =>
+    pgTable(
+        name,
+        {
+            id: serial("id").primaryKey(),
+            ptype: varchar("ptype", { length: valueLength }),
+            v0: varchar("v0", { length: valueLength }),
+            v1: varchar("v1", { length: valueLength }),
+            v2: varchar("v2", { length: valueLength }),
+            v3: varchar("v3", { length: valueLength }),
+            v4: varchar("v4", { length: valueLength }),
+            v5: varchar("v5", { length: valueLength }),
+        },
+        (table) => [index(`${name}_ptype_v0_v1_idx`).on(table.ptype, table.v0, table.v1)],
+    )

--- a/src/table/sqlite.ts
+++ b/src/table/sqlite.ts
@@ -1,0 +1,22 @@
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core"
+
+/**
+ * A SQLite casbin table shaped the way the adapter needs it. See
+ * {@link ../pg!pgCasbinTable} for the rationale; the shape is identical, with
+ * `text` in place of `varchar` since SQLite does not constrain length.
+ */
+export const sqliteCasbinTable = (name = "casbin_rule") =>
+    sqliteTable(
+        name,
+        {
+            id: integer("id").primaryKey({ autoIncrement: true }),
+            ptype: text("ptype"),
+            v0: text("v0"),
+            v1: text("v1"),
+            v2: text("v2"),
+            v3: text("v3"),
+            v4: text("v4"),
+            v5: text("v5"),
+        },
+        (table) => [index(`${name}_ptype_v0_v1_idx`).on(table.ptype, table.v0, table.v1)],
+    )

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,21 +1,60 @@
-export type TCasinTable = {
-    id: number
-    ptype: string | null
-    v0: string | null
-    v1: string | null
-    v2: string | null
-    v3: string | null
-    v4: string | null
-    v5: string | null
-}
+import type { Column, ColumnBaseConfig, ColumnDataType } from "drizzle-orm"
+import type { POLICY_COLUMNS } from "./index.js"
 
-export type TCasinTableCreateInput = {
-    id?: number | undefined
-    ptype?: string | null | undefined
-    v0?: string | null | undefined
-    v1?: string | null | undefined
-    v2?: string | null | undefined
-    v3?: string | null | undefined
-    v4?: string | null | undefined
-    v5?: string | null | undefined
-}
+/**
+ * Derived from the runtime tuple so the two cannot drift. The import is
+ * type-only on purpose: this module must emit no JavaScript, because `tsup`
+ * builds without bundling and would leave an unresolvable `./types` import in
+ * the ESM output.
+ */
+export type TPolicyColumn = (typeof POLICY_COLUMNS)[number]
+
+/**
+ * A stored rule as the adapter reads it. The table may carry any number of
+ * further columns (an `id`, timestamps, ...); none of them are read or written,
+ * so none of them appear here.
+ */
+export type TCasbinTable = { ptype: string | null } & Record<TPolicyColumn, string | null>
+
+/**
+ * A row as the adapter writes it. `ptype` is always supplied; a policy column is
+ * omitted when the rule is shorter than six values, and set to `null` when an
+ * update has to clear a value the previous rule used.
+ */
+export type TCasbinTableCreateInput = { ptype: string } & Partial<
+    Record<TPolicyColumn, string | null>
+>
+
+/**
+ * A column holding nullable text. Rules shorter than six values leave their
+ * unused columns NULL, `updatePolicy` clears columns by writing NULL, and
+ * `#matchLine` matches them with `IS NULL`, so a NOT NULL policy column cannot
+ * work — reject it at compile time rather than on the first short rule.
+ */
+type TNullableTextColumn = Column<
+    ColumnBaseConfig<ColumnDataType, string> & { data: string; notNull: false }
+>
+
+/**
+ * The columns every casbin table must expose. Only these property keys matter;
+ * each may map to any database column name. `ptype` is written on every row, so
+ * it is free to be NOT NULL.
+ */
+export type TCasbinColumns = { ptype: Column } & Record<TPolicyColumn, TNullableTextColumn>
+
+/**
+ * Which rules a filtered load should read, keyed by ptype. Each array holds the
+ * values a rule must have at `v0`, `v1`, ... in order; `""` matches anything at
+ * that position, and positions past the end of the array are unconstrained.
+ *
+ * A ptype the filter does not name is loaded in full, which is how casbin's own
+ * filtered adapters behave. The tenant of a rule lives in whichever policy
+ * column the model puts it in, so it sits at a different index per ptype:
+ *
+ * ```ts
+ * // p = sub, dom, obj, act  →  domain is v1
+ * // g = _, _, _             →  domain is v2
+ * await e.loadFilteredPolicy({ p: ["", "tenant_a"], g: ["", "", "tenant_a"] })
+ * ```
+ */
+export type TCasbinFilter = Record<string, readonly string[] | undefined>

--- a/test/dist.test.ts
+++ b/test/dist.test.ts
@@ -1,0 +1,45 @@
+import { existsSync } from "node:fs"
+import { createRequire } from "node:module"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+// Every other test imports from `../src`, so nothing else exercises what `tsup`
+// actually emits. `bundle: false` rewrites no import paths, which means any
+// runtime import of a module that is not its own entry point emits a specifier
+// Node cannot resolve — a break invisible to the rest of the suite.
+const require_ = createRequire(import.meta.url)
+const dist = join(import.meta.dirname, "..", "dist")
+
+describe.skipIf(!existsSync(dist))("built package", () => {
+    it("loads through the CommonJS entry points", () => {
+        expect(require_("../dist/index.js")).toHaveProperty("DrizzleAdapter")
+        expect(require_("../dist/table/pg.js")).toHaveProperty("pgCasbinTable")
+        expect(require_("../dist/table/mysql.js")).toHaveProperty("mysqlCasbinTable")
+        expect(require_("../dist/table/sqlite.js")).toHaveProperty("sqliteCasbinTable")
+    })
+
+    it("loads through the ES module entry points", async () => {
+        await expect(import("../dist/index.mjs")).resolves.toHaveProperty("DrizzleAdapter")
+        await expect(import("../dist/table/pg.mjs")).resolves.toHaveProperty("pgCasbinTable")
+        await expect(import("../dist/table/mysql.mjs")).resolves.toHaveProperty("mysqlCasbinTable")
+        await expect(import("../dist/table/sqlite.mjs")).resolves.toHaveProperty(
+            "sqliteCasbinTable",
+        )
+    })
+
+    it("builds a table the adapter accepts", async () => {
+        const { pgCasbinTable } = await import("../dist/table/pg.mjs")
+        const { getTableColumns } = await import("drizzle-orm")
+
+        expect(Object.keys(getTableColumns(pgCasbinTable("demo")))).toEqual([
+            "id",
+            "ptype",
+            "v0",
+            "v1",
+            "v2",
+            "v3",
+            "v4",
+            "v5",
+        ])
+    })
+})

--- a/test/dist.test.ts
+++ b/test/dist.test.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs"
 import { createRequire } from "node:module"
 import { join } from "node:path"
+import { pathToFileURL } from "node:url"
 import { describe, expect, it } from "vitest"
 
 // Every other test imports from `../src`, so nothing else exercises what `tsup`
@@ -10,26 +11,36 @@ import { describe, expect, it } from "vitest"
 const require_ = createRequire(import.meta.url)
 const dist = join(import.meta.dirname, "..", "dist")
 
+// Both loaders take the path as a value rather than a literal specifier. `dist`
+// is a build artifact and is absent on a clean checkout, so `import("../dist/
+// index.mjs")` would resolve at type-check time and fail `tsc --noEmit` before
+// anything has been built.
+const importESM = (file: string): Promise<Record<string, unknown>> =>
+    import(pathToFileURL(join(dist, file)).href) as Promise<Record<string, unknown>>
+
+const requireCJS = (file: string): Record<string, unknown> =>
+    require_(join(dist, file)) as Record<string, unknown>
+
 describe.skipIf(!existsSync(dist))("built package", () => {
     it("loads through the CommonJS entry points", () => {
-        expect(require_("../dist/index.js")).toHaveProperty("DrizzleAdapter")
-        expect(require_("../dist/table/pg.js")).toHaveProperty("pgCasbinTable")
-        expect(require_("../dist/table/mysql.js")).toHaveProperty("mysqlCasbinTable")
-        expect(require_("../dist/table/sqlite.js")).toHaveProperty("sqliteCasbinTable")
+        expect(requireCJS("index.js")).toHaveProperty("DrizzleAdapter")
+        expect(requireCJS("table/pg.js")).toHaveProperty("pgCasbinTable")
+        expect(requireCJS("table/mysql.js")).toHaveProperty("mysqlCasbinTable")
+        expect(requireCJS("table/sqlite.js")).toHaveProperty("sqliteCasbinTable")
     })
 
     it("loads through the ES module entry points", async () => {
-        await expect(import("../dist/index.mjs")).resolves.toHaveProperty("DrizzleAdapter")
-        await expect(import("../dist/table/pg.mjs")).resolves.toHaveProperty("pgCasbinTable")
-        await expect(import("../dist/table/mysql.mjs")).resolves.toHaveProperty("mysqlCasbinTable")
-        await expect(import("../dist/table/sqlite.mjs")).resolves.toHaveProperty(
-            "sqliteCasbinTable",
-        )
+        await expect(importESM("index.mjs")).resolves.toHaveProperty("DrizzleAdapter")
+        await expect(importESM("table/pg.mjs")).resolves.toHaveProperty("pgCasbinTable")
+        await expect(importESM("table/mysql.mjs")).resolves.toHaveProperty("mysqlCasbinTable")
+        await expect(importESM("table/sqlite.mjs")).resolves.toHaveProperty("sqliteCasbinTable")
     })
 
     it("builds a table the adapter accepts", async () => {
-        const { pgCasbinTable } = await import("../dist/table/pg.mjs")
         const { getTableColumns } = await import("drizzle-orm")
+        const { pgCasbinTable } = (await importESM("table/pg.mjs")) as {
+            pgCasbinTable: (name: string) => Parameters<typeof getTableColumns>[0]
+        }
 
         expect(Object.keys(getTableColumns(pgCasbinTable("demo")))).toEqual([
             "id",

--- a/test/interfaces.test.ts
+++ b/test/interfaces.test.ts
@@ -1,0 +1,244 @@
+import { newEnforcer, newModel } from "casbin"
+import { sql } from "drizzle-orm"
+import { drizzle } from "drizzle-orm/node-postgres"
+import { Pool } from "pg"
+import { afterAll, beforeEach, describe, expect, it } from "vitest"
+import { DrizzleAdapter } from "../src"
+import { pgCasbinTable } from "../src/table/pg"
+
+// A table of its own so this file cannot race the others.
+const casbinTable = pgCasbinTable("casbin_rule_interfaces")
+const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+const db = drizzle(pool)
+const adapter = DrizzleAdapter.newAdapter(db, casbinTable)
+
+const rows = async (): Promise<(string | null)[][]> => {
+    const found = await db.select().from(casbinTable)
+    return found
+        .map((r) => [r.ptype, r.v0, r.v1, r.v2, r.v3, r.v4, r.v5])
+        .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)))
+}
+
+const aclModel = () =>
+    newModel(`
+[request_definition]
+r = sub, obj, act
+[policy_definition]
+p = sub, obj, act
+[policy_effect]
+e = some(where (p.eft == allow))
+[matchers]
+m = r.sub == p.sub && r.obj == p.obj && r.act == p.act
+`)
+
+// The tenant lives inside the rule: v1 for `p`, v2 for `g`.
+const domainModel = () =>
+    newModel(`
+[request_definition]
+r = sub, dom, obj, act
+[policy_definition]
+p = sub, dom, obj, act
+[role_definition]
+g = _, _, _
+[policy_effect]
+e = some(where (p.eft == allow))
+[matchers]
+m = g(r.sub, p.sub, r.dom) && r.dom == p.dom && r.obj == p.obj && r.act == p.act
+`)
+
+const seedTenants = async () => {
+    await adapter.addPolicies("p", "p", [
+        ["admin", "tenant_a", "data1", "read"],
+        ["admin", "tenant_b", "data2", "read"],
+    ])
+    await adapter.addPolicies("g", "g", [
+        ["alice", "admin", "tenant_a"],
+        ["bob", "admin", "tenant_b"],
+    ])
+}
+
+beforeEach(async () => {
+    await db.execute(sql`
+        create table if not exists casbin_rule_interfaces (
+            id serial primary key not null,
+            ptype varchar(254), v0 varchar(254), v1 varchar(254),
+            v2 varchar(254), v3 varchar(254), v4 varchar(254), v5 varchar(254)
+        )`)
+    await db.delete(casbinTable)
+})
+
+afterAll(async () => {
+    await db.execute(sql`drop table if exists casbin_rule_interfaces`)
+    await pool.end()
+})
+
+describe("addPolicies", () => {
+    it("writes every rule in one transaction", async () => {
+        await adapter.addPolicies("p", "p", [
+            ["alice", "data1", "read"],
+            ["bob", "data2", "write"],
+        ])
+
+        expect(await rows()).toEqual([
+            ["p", "alice", "data1", "read", null, null, null],
+            ["p", "bob", "data2", "write", null, null, null],
+        ])
+    })
+
+    it("is a no-op on an empty batch", async () => {
+        await adapter.addPolicy("p", "p", ["alice", "data1", "read"])
+        await adapter.addPolicies("p", "p", [])
+
+        expect(await rows()).toEqual([["p", "alice", "data1", "read", null, null, null]])
+    })
+
+    it("validates every rule before writing any of them", async () => {
+        await expect(
+            adapter.addPolicies("p", "p", [
+                ["alice", "data1", "read"],
+                ["1", "2", "3", "4", "5", "6", "7"],
+            ]),
+        ).rejects.toThrow(/stores at most 6/)
+
+        expect(await rows()).toEqual([])
+    })
+
+    it("is reachable through the enforcer", async () => {
+        const enforcer = await newEnforcer(aclModel(), adapter)
+
+        await enforcer.addPolicies([
+            ["alice", "data1", "read"],
+            ["bob", "data2", "write"],
+        ])
+
+        expect(await rows()).toEqual([
+            ["p", "alice", "data1", "read", null, null, null],
+            ["p", "bob", "data2", "write", null, null, null],
+        ])
+    })
+})
+
+describe("removePolicies", () => {
+    it("removes only the listed rules, matching every column", async () => {
+        await adapter.addPolicies("p", "p", [
+            ["alice", "data1", "read"],
+            ["alice", "data2", "write"],
+            ["bob", "data3", "read"],
+        ])
+
+        await adapter.removePolicies("p", "p", [
+            ["alice", "data1", "read"],
+            ["bob", "data3", "read"],
+        ])
+
+        expect(await rows()).toEqual([["p", "alice", "data2", "write", null, null, null]])
+    })
+
+    it("does not empty the table on an empty batch", async () => {
+        await adapter.addPolicies("p", "p", [
+            ["alice", "data1", "read"],
+            ["bob", "data2", "write"],
+        ])
+
+        await adapter.removePolicies("p", "p", [])
+
+        expect(await rows()).toEqual([
+            ["p", "alice", "data1", "read", null, null, null],
+            ["p", "bob", "data2", "write", null, null, null],
+        ])
+    })
+
+    it("does not cross ptypes", async () => {
+        await adapter.addPolicy("p", "p", ["alice", "admin"])
+        await adapter.addPolicy("g", "g", ["alice", "admin"])
+
+        await adapter.removePolicies("p", "p", [["alice", "admin"]])
+
+        expect(await rows()).toEqual([["g", "alice", "admin", null, null, null, null]])
+    })
+})
+
+describe("loadFilteredPolicy", () => {
+    it("reads one tenant and leaves the rest in the table", async () => {
+        await seedTenants()
+
+        const model = domainModel()
+        await adapter.loadFilteredPolicy(model, {
+            p: ["", "tenant_a"],
+            g: ["", "", "tenant_a"],
+        })
+
+        expect(model.model.get("p")?.get("p")?.policy).toEqual([
+            ["admin", "tenant_a", "data1", "read"],
+        ])
+        expect(model.model.get("g")?.get("g")?.policy).toEqual([["alice", "admin", "tenant_a"]])
+        expect(adapter.isFiltered()).toBe(true)
+        // Nothing was deleted; the other tenant is still stored.
+        expect((await rows()).length).toBe(4)
+    })
+
+    it("treats an empty string as a wildcard", async () => {
+        await seedTenants()
+
+        const model = domainModel()
+        await adapter.loadFilteredPolicy(model, { p: ["admin", ""] })
+
+        expect(model.model.get("p")?.get("p")?.policy).toEqual([
+            ["admin", "tenant_a", "data1", "read"],
+            ["admin", "tenant_b", "data2", "read"],
+        ])
+    })
+
+    it("loads a ptype the filter does not name in full", async () => {
+        await seedTenants()
+
+        const model = domainModel()
+        await adapter.loadFilteredPolicy(model, { p: ["", "tenant_a"] })
+
+        expect(model.model.get("g")?.get("g")?.policy).toEqual([
+            ["alice", "admin", "tenant_a"],
+            ["bob", "admin", "tenant_b"],
+        ])
+    })
+
+    it("enforces on the loaded tenant only", async () => {
+        await seedTenants()
+
+        const enforcer = await newEnforcer(domainModel(), adapter)
+        await enforcer.loadFilteredPolicy({
+            p: ["", "tenant_a"],
+            g: ["", "", "tenant_a"],
+        })
+
+        expect(await enforcer.enforce("alice", "tenant_a", "data1", "read")).toBe(true)
+        // Filtered out, so it reads as a deny rather than an error.
+        expect(await enforcer.enforce("bob", "tenant_b", "data2", "read")).toBe(false)
+    })
+
+    it("refuses to save a filtered policy over the whole table", async () => {
+        await seedTenants()
+
+        const model = domainModel()
+        await adapter.loadFilteredPolicy(model, { p: ["", "tenant_a"] })
+
+        await expect(adapter.savePolicy(model)).rejects.toThrow(/Cannot save a filtered policy/)
+        expect((await rows()).length).toBe(4)
+    })
+
+    it("is a full, unfiltered load when the filter constrains nothing", async () => {
+        await seedTenants()
+
+        const model = domainModel()
+        await adapter.loadFilteredPolicy(model, {})
+
+        expect(model.model.get("p")?.get("p")?.policy?.length).toBe(2)
+        expect(adapter.isFiltered()).toBe(false)
+        await expect(adapter.savePolicy(model)).resolves.toBe(true)
+    })
+
+    it("rejects a filter longer than the policy columns", async () => {
+        await expect(
+            adapter.loadFilteredPolicy(domainModel(), { p: ["1", "2", "3", "4", "5", "6", "7"] }),
+        ).rejects.toThrow(/stores at most 6/)
+    })
+})

--- a/test/mysql.test.ts
+++ b/test/mysql.test.ts
@@ -1,0 +1,94 @@
+import { newEnforcer, newModel } from "casbin"
+import { sql } from "drizzle-orm"
+import { drizzle, type MySql2Database } from "drizzle-orm/mysql2"
+import { createPool, type Pool } from "mysql2/promise"
+import { afterAll, beforeEach, describe, expect, it } from "vitest"
+import { DrizzleAdapter } from "../src"
+import { mysqlCasbinTable } from "../src/table/mysql"
+
+// MySQL needs a server, so this file runs only when one is pointed at. CI
+// starts one; locally, set MYSQL_URL to run these.
+const url = process.env.MYSQL_URL
+const casbinTable = mysqlCasbinTable("casbin_rule")
+
+let pool: Pool
+let db: MySql2Database<Record<string, never>>
+let adapter: DrizzleAdapter<MySql2Database<Record<string, never>>, Record<string, never>>
+
+const rows = async (): Promise<(string | null)[][]> => {
+    const found = await db.select().from(casbinTable)
+    return found
+        .map((r) => [r.ptype, r.v0, r.v1, r.v2, r.v3, r.v4, r.v5])
+        .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)))
+}
+
+const aclModel = () =>
+    newModel(`
+[request_definition]
+r = sub, obj, act
+[policy_definition]
+p = sub, obj, act
+[policy_effect]
+e = some(where (p.eft == allow))
+[matchers]
+m = r.sub == p.sub && r.obj == p.obj && r.act == p.act
+`)
+
+describe.skipIf(!url)("mysql", () => {
+    beforeEach(async () => {
+        pool ??= createPool(url as string)
+        db ??= drizzle(pool)
+        adapter ??= DrizzleAdapter.newAdapter(db, casbinTable)
+
+        await db.execute(sql`
+            create table if not exists casbin_rule (
+                id int auto_increment primary key,
+                ptype varchar(254), v0 varchar(254), v1 varchar(254),
+                v2 varchar(254), v3 varchar(254), v4 varchar(254), v5 varchar(254)
+            )`)
+        await db.delete(casbinTable)
+    })
+
+    afterAll(async () => {
+        await pool?.end()
+    })
+
+    it("round-trips a policy through save and load", async () => {
+        const model = aclModel()
+        model.addPolicy("p", "p", ["alice", "data1", "read"])
+        model.addPolicy("p", "p", ["bob", "data2", "write"])
+        await adapter.savePolicy(model)
+
+        expect(await rows()).toEqual([
+            ["p", "alice", "data1", "read", null, null, null],
+            ["p", "bob", "data2", "write", null, null, null],
+        ])
+
+        const enforcer = await newEnforcer(aclModel(), adapter)
+        expect(await enforcer.enforce("alice", "data1", "read")).toBe(true)
+        expect(await enforcer.enforce("bob", "data1", "read")).toBe(false)
+    })
+
+    it("adds, updates and removes a single rule", async () => {
+        await adapter.addPolicy("p", "p", ["alice", "data1", "read"])
+        await adapter.addPolicy("p", "p", ["alice", "data1", "write"])
+
+        await adapter.updatePolicy("p", "p", ["alice", "data1", "read"], ["alice", "data3"])
+        expect(await rows()).toEqual([
+            ["p", "alice", "data1", "write", null, null, null],
+            ["p", "alice", "data3", null, null, null, null],
+        ])
+
+        await adapter.removePolicy("p", "p", ["alice", "data3"])
+        expect(await rows()).toEqual([["p", "alice", "data1", "write", null, null, null]])
+    })
+
+    it("removes a filtered range without touching other ptypes", async () => {
+        await adapter.addPolicy("p", "p", ["alice", "data1", "read"])
+        await adapter.addPolicy("g", "g", ["alice", "admin"])
+
+        await adapter.removeFilteredPolicy("p", "p", 0, "alice")
+
+        expect(await rows()).toEqual([["g", "alice", "admin", null, null, null, null]])
+    })
+})

--- a/test/regressions.test.ts
+++ b/test/regressions.test.ts
@@ -4,7 +4,7 @@ import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres"
 import { pgTable, serial, varchar } from "drizzle-orm/pg-core"
 import { Pool } from "pg"
 import { afterAll, beforeEach, describe, expect, it } from "vitest"
-import { DrizzleAdapter } from "../src"
+import { DrizzleAdapter, type TCasbinSchema } from "../src"
 
 // A table of its own so this file cannot race test/adapter.test.ts.
 const regressionTable = pgTable("casbin_rule_regression", {
@@ -260,11 +260,29 @@ describe("addPolicy", () => {
 describe("constructor", () => {
     it("rejects a table missing casbin columns", () => {
         const bad = pgTable("bad_table", { id: serial("id").primaryKey() })
+        // The type rejects this table too; the runtime guard is what catches a
+        // JavaScript caller, and a caller who has cast the type away.
+        // @ts-expect-error -- table is missing ptype and v0..v5
         expect(() => DrizzleAdapter.newAdapter(db, bad)).toThrow(
             /"bad_table" is missing the casbin column\(s\): ptype, v0, v1, v2, v3, v4, v5/,
         )
     })
 })
+
+// Type-level regression: a NOT NULL policy column cannot round-trip a short
+// rule, so the schema type has to reject it before any query runs.
+const notNullTable = pgTable("not_null_table", {
+    ptype: varchar("ptype", { length: 254 }),
+    v0: varchar("v0", { length: 254 }).notNull(),
+    v1: varchar("v1", { length: 254 }),
+    v2: varchar("v2", { length: 254 }),
+    v3: varchar("v3", { length: 254 }),
+    v4: varchar("v4", { length: 254 }),
+    v5: varchar("v5", { length: 254 }),
+})
+// @ts-expect-error -- v0 is NOT NULL
+const _rejectsNotNullColumns: TCasbinSchema = notNullTable
+void _rejectsNotNullColumns
 
 describe("error categorization", () => {
     const stubAdapter = (thrown: unknown) => {

--- a/test/sqlite.test.ts
+++ b/test/sqlite.test.ts
@@ -1,0 +1,93 @@
+import { newEnforcer, newModel } from "casbin"
+import { sql } from "drizzle-orm"
+import { drizzle } from "drizzle-orm/libsql"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterAll, beforeEach, describe, expect, it } from "vitest"
+import { DrizzleAdapter } from "../src"
+import { sqliteCasbinTable } from "../src/table/sqlite"
+
+// SQLite runs in-process, so this file needs no server and covers the dialect
+// the adapter claims to support but only ever type-checked. `TQueryRunner`
+// assumes the three dialects' query builders are structurally identical; these
+// tests are what makes that assumption more than a comment.
+const casbinTable = sqliteCasbinTable("casbin_rule")
+// Not `:memory:`: libsql hands each pooled connection its own in-memory
+// database, so the connection a transaction runs on would not see this table.
+const directory = mkdtempSync(join(tmpdir(), "casbin-drizzle-"))
+const db = drizzle({ connection: { url: `file:${join(directory, "test.db")}` } })
+const adapter = DrizzleAdapter.newAdapter(db, casbinTable)
+
+const rows = async (): Promise<(string | null)[][]> => {
+    const found = await db.select().from(casbinTable)
+    return found
+        .map((r) => [r.ptype, r.v0, r.v1, r.v2, r.v3, r.v4, r.v5])
+        .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)))
+}
+
+const aclModel = () =>
+    newModel(`
+[request_definition]
+r = sub, obj, act
+[policy_definition]
+p = sub, obj, act
+[policy_effect]
+e = some(where (p.eft == allow))
+[matchers]
+m = r.sub == p.sub && r.obj == p.obj && r.act == p.act
+`)
+
+beforeEach(async () => {
+    await db.run(sql`
+        create table if not exists casbin_rule (
+            id integer primary key autoincrement,
+            ptype text, v0 text, v1 text, v2 text, v3 text, v4 text, v5 text
+        )`)
+    await db.delete(casbinTable)
+})
+
+afterAll(() => {
+    rmSync(directory, { recursive: true, force: true })
+})
+
+describe("sqlite", () => {
+    it("round-trips a policy through save and load", async () => {
+        const model = aclModel()
+        model.addPolicy("p", "p", ["alice", "data1", "read"])
+        model.addPolicy("p", "p", ["bob", "data2", "write"])
+        await adapter.savePolicy(model)
+
+        expect(await rows()).toEqual([
+            ["p", "alice", "data1", "read", null, null, null],
+            ["p", "bob", "data2", "write", null, null, null],
+        ])
+
+        const enforcer = await newEnforcer(aclModel(), adapter)
+        expect(await enforcer.enforce("alice", "data1", "read")).toBe(true)
+        expect(await enforcer.enforce("bob", "data1", "read")).toBe(false)
+    })
+
+    it("adds, updates and removes a single rule", async () => {
+        await adapter.addPolicy("p", "p", ["alice", "data1", "read"])
+        await adapter.addPolicy("p", "p", ["alice", "data1", "write"])
+
+        await adapter.updatePolicy("p", "p", ["alice", "data1", "read"], ["alice", "data3"])
+        expect(await rows()).toEqual([
+            ["p", "alice", "data1", "write", null, null, null],
+            ["p", "alice", "data3", null, null, null, null],
+        ])
+
+        await adapter.removePolicy("p", "p", ["alice", "data3"])
+        expect(await rows()).toEqual([["p", "alice", "data1", "write", null, null, null]])
+    })
+
+    it("removes a filtered range without touching other ptypes", async () => {
+        await adapter.addPolicy("p", "p", ["alice", "data1", "read"])
+        await adapter.addPolicy("g", "g", ["alice", "admin"])
+
+        await adapter.removeFilteredPolicy("p", "p", 0, "alice")
+
+        expect(await rows()).toEqual([["g", "alice", "admin", null, null, null, null]])
+    })
+})

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+    // Declarations are emitted by `tsc`, not by tsup: tsup's dts pass forces
+    // `baseUrl` on the compiler (`baseUrl: compilerOptions.baseUrl || "."` in
+    // its rollup worker), and `baseUrl` is deprecated — TS 6 errors on it and
+    // TS 7 drops it. There is no tsconfig setting that stops the injection.
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "rootDir": "src",
+        "outDir": "dist"
+    },
+    // Only the published sources: tests must not land in dist.
+    "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
         "ignoreDeprecations": "6.0"
     },
     "exclude": ["node_modules"],
-    "include": ["src/index.ts", "test", "tsup.config.ts"]
+    "include": ["src", "test", "tsup.config.ts", "drizzle.config.ts"]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,10 +1,16 @@
 import { defineConfig, type Options } from "tsup"
 
 export default defineConfig((options: Options) => ({
-    entry: ["src/index.ts"],
+    // `bundle: false` emits one file per entry and rewrites no import paths, so
+    // every module imported at runtime must be an entry of its own. src/types.ts
+    // is absent by design: it is type-only and erases to nothing.
+    entry: ["src/index.ts", "src/table/pg.ts", "src/table/mysql.ts", "src/table/sqlite.ts"],
     clean: true,
     format: ["cjs", "esm"],
-    dts: true,
+    // Declarations come from `tsc -p tsconfig.build.json` instead: tsup's dts
+    // pass forces the deprecated `baseUrl` on the compiler, which TS 6 errors
+    // on and TS 7 removes. See tsconfig.build.json.
+    dts: false,
     bundle: false,
     ...options,
 }))


### PR DESCRIPTION
Follows #14. That PR fixed the rules the adapter was already writing; this one covers the casbin interfaces it never implemented, the drivers it turned away, and a build that stops working on the next TypeScript major.

Three changesets are included, so the release notes carry the same detail as this description.

---

## 1. `BatchAdapter` — `addPolicies` / `removePolicies`

The class declared `implements UpdatableAdapter` only. casbin checks for the batch methods at call time, so `e.addPolicies([...])` did not fail at compile time — it threw at runtime:

```
cannot to save policy, the adapter does not implement the BatchAdapter
```

Same for `e.addPoliciesEx()` and `e.removePolicies()`. Anyone seeding a policy table had to loop over `addPolicy`, one round trip per rule.

Both are implemented now. Each validates every rule *before* writing any of them — a malformed rule at index 400 must not leave the first 399 committed — runs in a single transaction, and chunks its statements at 1000 to stay inside Postgres's 65535 bind-parameter cap.

One case worth calling out, because it is the difference between a no-op and data loss: `removePolicies(sec, ptype, [])`. The conditions are combined with `or()`, and `or()` over an empty list returns `undefined`, which drizzle renders as a `DELETE` with **no `WHERE` clause at all**. An empty batch now returns before the statement is built. There is a test that asserts the table survives it.

## 2. `FilteredAdapter` — `loadFilteredPolicy` / `isFiltered`

`e.loadFilteredPolicy(...)` threw too. It matters more than the batch methods: `loadPolicy` issues an unbounded `SELECT` and holds the entire table in memory, so a table shared by fifty tenants loads all fifty to enforce one.

The filter is pushed into SQL rather than applied after the read:

```ts
// p = sub, dom, obj, act  →  the tenant is v1
// g = _, _, _             →  the tenant is v2
await e.loadFilteredPolicy({ p: ["", "tenant_a"], g: ["", "", "tenant_a"] })
```

which renders roughly

```sql
WHERE (ptype = 'p' AND v1 = 'tenant_a')
   OR (ptype = 'g' AND v2 = 'tenant_a')
   OR ptype NOT IN ('p', 'g')
```

The semantics match casbin's own filtered adapters: `""` matches anything at that position, positions past the end of the array are unconstrained, and a ptype the filter does not name is loaded in full — that is the third branch above.

Two things are deliberate and documented in the README rather than silently handled:

- **A filter narrower than the model needs is not an error.** The missing rules never load and `enforce` reports a deny. That is quiet, so it is written down.
- **`savePolicy` is refused after a filtered load.** It truncates the table before writing, and after a filtered load the model holds only what the filter matched — saving would delete every rule outside it. The adapter tracks `#filtered` and throws with an explanation. casbin's enforcer refuses this too; this covers callers holding the adapter directly.

There is no tenant column, and there should not be one: a rule is filterable by the values it already stores, which is what casbin's domain models are for. Because the tenant lands at a different index per ptype, the filter is written per ptype.

`loadPolicy` is now tagged `@deprecated` pointing at `loadFilteredPolicy`. It stays supported and correct — casbin's `Adapter` interface requires it and `newEnforcer` calls it — the tag is guidance for large tables, not a removal notice.

## 3. Driver support

Postgres and MySQL were typed as `NodePgDatabase` and `MySql2Database`, i.e. two specific drivers, though nothing in the adapter depends on either. They are now typed against drizzle's dialect base classes (`PgDatabase`, `MySqlDatabase`), so postgres.js, neon, vercel-postgres, PGlite and planetscale type-check.

`better-sqlite3` is still excluded on purpose. It is `BaseSQLiteDatabase<"sync", ...>` — its transaction callbacks are synchronous, so it would not await this adapter's writes. The union accepts `"async"` only, and the README says so instead of leaving people to discover it.

SQLite was in a strange half-state before: `schema` accepted an `SQLiteTable`, but the database parameter did not, so the documented support was unreachable.

## 4. Table helpers, as new subpath exports

```ts
import { pgCasbinTable } from "casbin-drizzle-adapter/pg"

export const casbinTable = pgCasbinTable("casbin_rule")
```

`/mysql` and `/sqlite` export the equivalents. Each builds a correctly shaped table plus an index on `(ptype, v0, v1)` — the columns every equality lookup uses (`removePolicy`, `updatePolicy`, a filtered load). They are separate entry points so a Postgres user does not pull in MySQL and SQLite dialect code. Hand-written tables keep working; this is a convenience.

## 5. A wrong table is now a compile error

`TCasbinSchema` requires the table to expose `ptype` and `v0..v5`, and requires `v0..v5` to be **nullable** text. A `NOT NULL` policy column cannot store a rule shorter than six values, and `updatePolicy` clears unused columns by writing `NULL`, so such a table failed on its first short rule. It no longer compiles.

Only the property keys are constrained — never the SQL names. The table and each of its columns may still be called anything in the database.

The runtime guard in the constructor stays, because a JavaScript caller reaches it untyped. The row types also no longer claim an `id` column: the adapter never reads or writes one, so a table without `id` is now typed honestly.

## 6. The build (this is the part that was actively broken)

`pnpm build` failed on the installed TypeScript:

```
error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
```

tsup injects it. Its dts pass does `baseUrl: compilerOptions.baseUrl || "."` in the rollup worker, overriding whatever the tsconfig says, so there is no tsconfig setting that avoids it. The workaround in `tsconfig.json` was `"ignoreDeprecations": "6.0"`, which silences the error for exactly one major version — TS 7 drops the option and the build breaks again.

So declarations move off tsup: `tsup --minify` builds JavaScript, `tsc -p tsconfig.build.json` emits declarations, and `scripts/copy-declarations.mjs` writes the `.d.mts` twin each ESM entry needs (a `.d.ts` in a `"type": "commonjs"` package is read as CommonJS, which would type the `.mjs` output as CommonJS for consumers).

Two consequences:

- Declarations are no longer rolled up into one file per entry, so `dist/types.d.ts` ships alongside them. Covered by the existing `"files": ["dist"]`.
- The two relative imports in `src` are written with an explicit `.js` extension. Rolled-up declarations had no relative specifiers at all; emitted ones do, and an extensionless specifier is an error for consumers on `node16`/`nodenext` resolution who do not set `skipLibCheck`.

## 7. Packaging

The package now declares an `exports` map and `"sideEffects": false`, and lists `casbin` and `drizzle-orm` as **peer dependencies** — both are required at runtime but were listed nowhere, so installing the package pulled in neither.

⚠️ **Breaking for anyone doing it:** deep imports into `casbin-drizzle-adapter/dist/*` no longer resolve, now that an `exports` map exists. Use the package entry or one of the three subpaths.

## 8. Tests and CI

MySQL and SQLite were supported by types alone; both now have real test files. SQLite runs in-process through libsql (on a temp file, not `:memory:` — libsql gives each pooled connection its own in-memory database, so a transaction would not see the table). MySQL runs when `MYSQL_URL` is set and skips otherwise, so a local run without a MySQL server stays green.

`test/dist.test.ts` loads the **built** package through every entry point in both module formats. Every other test imports from `../src`, so nothing exercised what tsup actually emits — and with `bundle: false`, any runtime import of a module that is not its own entry emits a specifier Node cannot resolve, a break the rest of the suite cannot see.

The workflow ran on push to `main` only, so nothing checked a PR before merge. It now runs on both, with the release job gated on `github.event_name == 'push'` so a PR run never publishes. It also:

- adds a MySQL service, health-checked with a real query (`mysqladmin ping` reports ready ~30s before the server accepts one);
- adds a health check to the Postgres service, which had none;
- runs `typecheck` and `build`, so a broken declaration emit fails CI rather than release;
- swaps `pnpm format` for `pnpm format:check` — rewriting files in CI reports success no matter how the code was formatted.

## Verified locally

`format:check`, `lint`, `typecheck`, `build`, and the full suite against Postgres 16 and MySQL 8.4 in Docker: **52 passed, 0 failed**. `changeset status` reports a `minor` bump.

## Not in scope

- `UpdatableAdapter.updatePolicies` / `updateFilteredPolicies` — still unimplemented.
- `better-sqlite3` — would need a synchronous write path throughout.
- `loadPolicy` remains unbounded by design; `loadFilteredPolicy` is the answer for large tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
